### PR TITLE
[fix] allow multiple active tokens

### DIFF
--- a/backend/src/main/java/com/etjelesni/backend/config/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/etjelesni/backend/config/OAuth2LoginSuccessHandler.java
@@ -44,15 +44,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         User user = userService.createOrGetUser(email, firstName, lastName);
         String jwtToken = jwtService.generateToken(user);
 
-        // Revoke any existing non-revoked tokens for this user
-        List<Token> activeTokens = tokenRepository.findAllByUserAndRevokedFalse(user);
-        if (!activeTokens.isEmpty()) {
-            for (Token t : activeTokens) {
-                t.setRevoked(true);
-            }
-            tokenRepository.saveAll(activeTokens);
-        }
-
         // Save the new token
         Token token = new Token();
         token.setToken(jwtToken);


### PR DESCRIPTION
This pull request simplifies the OAuth2 authentication success handling logic by removing the step that revoked all previously active tokens for a user. Now, when a user logs in, the system no longer revokes their existing tokens before issuing a new one.

Authentication token management changes:

* Removed logic in `OAuth2LoginSuccessHandler.java` that revoked all existing non-revoked tokens for a user upon successful authentication. Now, only the new token is saved without affecting previous tokens.