### PR TITLE
[fix] jwt validation

### DIFF
--- a/backend/src/main/java/com/etjelesni/backend/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/etjelesni/backend/config/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -129,7 +129,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
         
-        Map<String, Object> errorResponse = new HashMap<>();
+        Map<String, Object> errorResponse = new LinkedHashMap<>();
         errorResponse.put("timestamp", LocalDateTime.now().toString());
         errorResponse.put("status", 401);
         errorResponse.put("error", "Unauthorized");


### PR DESCRIPTION
This pull request enhances the `JwtAuthenticationFilter` to improve JWT error handling and allow certain public endpoints to bypass authentication. The main improvements include skipping JWT checks for specified URL patterns and providing clearer error responses for expired or invalid tokens.

**Public endpoint exclusion:**

* Added a list of URL patterns (`EXCLUDE_URLS`) to skip JWT authentication for endpoints like `/api/hello` and `/swagger-ui/**`, using `AntPathMatcher` and the `shouldNotFilter` override.

**JWT error handling and response improvements:**

* Wrapped JWT parsing in a try-catch block to handle expired or invalid tokens, clearing the security context and returning a custom JSON error response when needed.
* Implemented the `sendUnauthorizedJson` helper to return a structured JSON error with timestamp, status, error type, message, and request path for unauthorized access attempts.

**Dependency and import updates:**

* Added new imports for JWT exceptions, path matching, and date formatting to support the above changes. [[1]](diffhunk://#diff-0e8439326129e7638404ca9405ed2b6ce3a7801ca9177edb44adb2b5740bbaaaR4-R5) [[2]](diffhunk://#diff-0e8439326129e7638404ca9405ed2b6ce3a7801ca9177edb44adb2b5740bbaaaR19-R25)